### PR TITLE
Update and rename teiher.gr.toml to teicrete.gr.toml

### DIFF
--- a/g/gr/teicrete.gr.toml
+++ b/g/gr/teicrete.gr.toml
@@ -1,0 +1,3 @@
+name = "Technological Education Institute of Crete"
+sld = "teicrete"
+tld = "gr"

--- a/g/gr/teiher.gr.toml
+++ b/g/gr/teiher.gr.toml
@@ -1,3 +1,0 @@
-name = "Technological Education Institute of Heraklion"
-sld = "teiher"
-tld = "gr"


### PR DESCRIPTION
The institute was renamed from "Technological Educational Institute of Heraklion" (teiher.gr) into "Technological Educational Institute of Crete" (teicrete.gr)
