### PR TITLE
Sakarya University

### DIFF
--- a/e/edu.tr/sakarya.edu.tr.toml
+++ b/e/edu.tr/sakarya.edu.tr.toml
@@ -1,3 +1,3 @@
 name = "Sakarya University"
-sld = "sau"
+sld = "sakarya"
 tld = "edu.tr"


### PR DESCRIPTION
Sakarya University is using sakarya.edu.tr, sau.edu.tr is old domain.
